### PR TITLE
Make a_filename const char* in Load/Save methods 

### DIFF
--- a/Genome.cpp
+++ b/Genome.cpp
@@ -2392,7 +2392,7 @@ void Genome::CalculateDepth()
 //////////////////////////////////////////////////////////////////////////////////
 
 // Builds this genome from a file
-Genome::Genome(char* a_FileName)
+Genome::Genome(const char* a_FileName)
 {
     std::ifstream t_DataFile(a_FileName);
     *this = Genome(t_DataFile);
@@ -2489,7 +2489,7 @@ Genome::Genome(std::ifstream& a_DataFile)
 
 
 // Saves this genome to a file
-void Genome::Save(char* a_FileName)
+void Genome::Save(const char* a_FileName)
 {
     FILE* t_file;
     t_file = fopen(a_FileName, "w");

--- a/Genome.h
+++ b/Genome.h
@@ -150,7 +150,7 @@ public:
     bool operator==(Genome const& other) const { return m_ID == other.m_ID; }
 
     // Builds this genome from a file
-    Genome(char* a_filename);
+    Genome(const char* a_filename);
 
     // Builds this genome from an opened file
     Genome(std::ifstream& a_DataFile);
@@ -272,7 +272,7 @@ public:
     void BuildHyperNEATPhenotype(NeuralNetwork& net, Substrate& subst);
 
     // Saves this genome to a file
-    void Save(char* a_filename);
+    void Save(const char* a_filename);
 
     // Saves this genome to an already opened file for writing
     void Save(FILE* a_fstream);

--- a/NeuralNetwork.cpp
+++ b/NeuralNetwork.cpp
@@ -782,7 +782,7 @@ void NeuralNetwork::RTRL_update_weights()
 	m_total_error = 0;
 }
 
-void NeuralNetwork::Save(char* a_filename)
+void NeuralNetwork::Save(const char* a_filename)
 {
 	FILE* fil = fopen(a_filename, "w");
 	Save(fil);
@@ -912,7 +912,7 @@ bool NeuralNetwork::Load(std::ifstream& a_DataFile)
 
     return true;
 }
-bool NeuralNetwork::Load(char *a_filename)
+bool NeuralNetwork::Load(const char *a_filename)
 {
     std::ifstream t_DataFile(a_filename);
     return Load(t_DataFile);

--- a/NeuralNetwork.h
+++ b/NeuralNetwork.h
@@ -183,8 +183,8 @@ public:
     }
 
     // one-shot save/load
-    void Save(char* a_filename);
-    bool Load(char* a_filename);
+    void Save(const char* a_filename);
+    bool Load(const char* a_filename);
 
     // save/load from already opened files for reading/writing
     void Save(FILE* a_file);

--- a/Parameters.cpp
+++ b/Parameters.cpp
@@ -703,7 +703,7 @@ int Parameters::Load(std::ifstream& a_DataFile)
 }
 
 
-int Parameters::Load(char* a_FileName)
+int Parameters::Load(const char* a_FileName)
 {
     std::ifstream data(a_FileName);
     if (!data.is_open())
@@ -714,7 +714,7 @@ int Parameters::Load(char* a_FileName)
     return result;
 }
 
-void Parameters::Save(char* filename)
+void Parameters::Save(const char* filename)
 {
 	FILE* f = fopen(filename, "w");
 	Save(f);

--- a/Parameters.h
+++ b/Parameters.h
@@ -347,11 +347,11 @@ public:
 
     // Load the parameters from a file
     // returns 0 on success
-    int Load(char* filename);
+    int Load(const char* filename);
     // Load the parameters from an already opened file for reading
     int Load(std::ifstream& a_DataFile);
 
-    void Save(char* filename);
+    void Save(const char* filename);
     // Saves the parameters to an already opened file for writing
     void Save(FILE* a_fstream);
 

--- a/Population.cpp
+++ b/Population.cpp
@@ -102,7 +102,7 @@ Population::Population(const Genome& a_Seed, const Parameters& a_Parameters, boo
 }
 
 
-Population::Population(char *a_FileName)
+Population::Population(const char *a_FileName)
 {
     m_BestFitnessEver = 0.0;
 
@@ -163,7 +163,7 @@ Population::Population(char *a_FileName)
 
 
 // Save a whole population to a file
-void Population::Save(char* a_FileName)
+void Population::Save(const char* a_FileName)
 {
     FILE* t_file = fopen(a_FileName, "w");
 

--- a/Population.h
+++ b/Population.h
@@ -149,7 +149,7 @@ public:
 
 
     // Loads a population from a file.
-    Population(char* a_FileName);
+    Population(const char* a_FileName);
 
     ////////////////////////////
     // Destructor
@@ -193,7 +193,7 @@ public:
     void Epoch();
 
     // Saves the whole population to a file
-    void Save(char* a_FileName);
+    void Save(const char* a_FileName);
 
     //////////////////////
     // NEW STUFF

--- a/PythonBindings.h
+++ b/PythonBindings.h
@@ -117,12 +117,12 @@ BOOST_PYTHON_MODULE(MultiNEAT)
 			.def_readwrite("substrate_coords", &Neuron::m_substrate_coords)
 			;
 
-	void (NeuralNetwork::*NN_Save)(char*) = &NeuralNetwork::Save;
-	bool (NeuralNetwork::*NN_Load)(char*) = &NeuralNetwork::Load;
-	void (Genome::*Genome_Save)(char*) = &Genome::Save;
+	void (NeuralNetwork::*NN_Save)(const char*) = &NeuralNetwork::Save;
+	bool (NeuralNetwork::*NN_Load)(const char*) = &NeuralNetwork::Load;
+	void (Genome::*Genome_Save)(const char*) = &Genome::Save;
 	void (NeuralNetwork::*NN_Input)(list&) = &NeuralNetwork::Input;
-	void (Parameters::*Parameters_Save)(char*) = &Parameters::Save;
-	int (Parameters::*Parameters_Load)(char*) = &Parameters::Load;
+	void (Parameters::*Parameters_Save)(const char*) = &Parameters::Save;
+	int (Parameters::*Parameters_Load)(const char*) = &Parameters::Load;
 
 	class_<NeuralNetwork>("NeuralNetwork", init<>())
 


### PR DESCRIPTION
This affects the Genome, NeuralNetwork, Parameters and Population,
classes.  Since a_filename is not modified by the Load/Save methods, it
makes sense for it to be const. Having a_filename be const simplifies
interaction with callers that use std::strings.

The changes are backwards compatible - you can still pass a char\* for
a_filename.

---

Just thought I'd pass this along in case you want to make the package easier to use with std::string.c_str. 

Thanks for a good library!
