### PR TITLE
Fix missing vector include in Traits.h

### DIFF
--- a/src/Traits.h
+++ b/src/Traits.h
@@ -6,6 +6,7 @@
 #define MULTINEAT_TRAITS_H
 
 #include <string>
+#include <vector>
 #include <boost/any.hpp>
 #include <boost/variant.hpp>
 #include <cmath>


### PR DESCRIPTION
Vector doesn't seem to be pulled in by other headers on some systems (eg. Arch Linux), requiring it to be manually included in Traits.h.

I've added an extra include line to remedy this, and it shouldn't have any side effects.