### PR TITLE
Make Compilable without Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,12 @@ include(FindPythonLibs)
 set(Boost_USE_STATIC_LIBS       OFF) # only find static libs
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME    OFF)
-find_package(Boost COMPONENTS date_time system filesystem python3 serialization)
+find_package(Boost COMPONENTS
+    date_time
+    system
+    filesystem
+    python3
+    serialization)
 if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
 endif()

--- a/src/Genes.h
+++ b/src/Genes.h
@@ -168,11 +168,13 @@ namespace NEAT
                     int idx = a_RNG.Roulette(probs);
                     t = itp.set[idx];
                 }
+#ifdef USE_BOOST_PYTHON
                 if (it->second.type == "pyobject")
                 {
                     py::object itp = bs::get<py::object>(it->second.m_Details);
                     t = itp(); // details is a function that returns a random instance of the trait
                 }
+#endif
 
                 Trait tr;
                 tr.value = t;
@@ -197,12 +199,14 @@ namespace NEAT
                 }
 
                 // if generic python object, forward all processing to its method
+#ifdef USE_BOOST_PYTHON
                 if (mine.type() == typeid(py::object))
                 {
                     // call mating function
                     m_Traits[it->first].value = bs::get<py::object>(mine).attr("mate")(bs::get<py::object>(yours));
                 }
                 else
+#endif
                 {
 
                     if (a_RNG.RandFloat() < 0.5) // pick either one
@@ -388,11 +392,13 @@ namespace NEAT
                         if(cur.value != itp.set[idx].value)
                             did_mutate = true;
                     }
+#ifdef USE_BOOST_PYTHON
                     if (it->second.type == "pyobject")
                     {
                         m_Traits[it->first].value = bs::get<py::object>(m_Traits[it->first].value).attr("mutate")();
                         did_mutate = true;
                     }
+#endif
                 }
             }
 
@@ -473,11 +479,13 @@ namespace NEAT
                         // distance between floats - calculate directly
                         dist[it->first] = abs((bs::get<floatsetelement>(mine)).value - (bs::get<floatsetelement>(yours)).value);
                     }
+#ifdef USE_BOOST_PYTHON
                     if (mine.type() == typeid(py::object))
                     {
                         // distance between objects - calculate via method
                         dist[it->first] = py::extract<double>(bs::get<py::object>(mine).attr("distance_to")(bs::get<py::object>(yours)));
                     }
+#endif
                 }
             }
 

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -465,7 +465,9 @@ namespace NEAT
 
     Parameters::Parameters()
     {
+#ifdef USE_BOOST_PYTHON
         Py_Initialize();
+#endif
 
         Reset();
     }

--- a/src/Traits.h
+++ b/src/Traits.h
@@ -11,14 +11,18 @@
 #include <boost/variant.hpp>
 #include <cmath>
 
+#ifdef USE_BOOST_PYTHON
 #include <boost/python.hpp>
+#endif
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/shared_ptr.hpp>
 
 namespace bs = boost;
+#ifdef USE_BOOST_PYTHON
 namespace py = bs::python;
+#endif
 
 namespace NEAT
 {
@@ -45,7 +49,11 @@ namespace NEAT
         double value;
     };
     
-    typedef bs::variant<int, double, std::string, intsetelement, floatsetelement, py::object> TraitType;
+    typedef bs::variant<int, double, std::string, intsetelement, floatsetelement
+#ifdef USE_BOOST_PYTHON
+  , py::object
+#endif
+    > TraitType;
 
     class IntTraitParameters
     {
@@ -106,8 +114,11 @@ namespace NEAT
                     FloatTraitParameters,
                     StringTraitParameters,
                     IntSetTraitParameters,
-                    FloatSetTraitParameters,
-                    py::object> m_Details;
+                    FloatSetTraitParameters
+#ifdef USE_BOOST_PYTHON
+                  , py::object
+#endif
+        > m_Details;
 
         std::string dep_key; // counts only if this other trait exists..
         std::vector<TraitType> dep_values; // and has one of these values


### PR DESCRIPTION
Encapsulated every python dependent code with USE_BOOST_PYTHON. Can now
be compiled as true cpp application/library.