### PR TITLE
Fixed py::numeric::array compatibility with boost >= 1.65

### DIFF
--- a/src/NeuralNetwork.cpp
+++ b/src/NeuralNetwork.cpp
@@ -625,7 +625,7 @@ void NeuralNetwork::Input_python_list(py::list& a_Inputs)
     Input(inp);
 }
 
-void NeuralNetwork::Input_numpy(py::numeric::array& a_Inputs)
+void NeuralNetwork::Input_numpy(pyndarray& a_Inputs)
 {
     int len = py::len(a_Inputs);
     std::vector<double> inp;

--- a/src/NeuralNetwork.h
+++ b/src/NeuralNetwork.h
@@ -33,12 +33,25 @@
 #ifdef USE_BOOST_PYTHON
 
 #include <boost/python.hpp>
-#include <boost/python/numeric.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION < 106500
+    #include <boost/python/numeric.hpp>
+#else
+    #include <boost/python/numpy.hpp>
+#endif
+
 #include <boost/python/tuple.hpp>
 #include <math.h>
 #include <cmath>
 
 namespace py = boost::python;
+
+#if BOOST_VERSION < 106500
+    typedef typename py::numeric::array pyndarray;
+#else
+    typedef typename py::numpy::ndarray pyndarray;
+#endif
 
 #endif
 
@@ -157,7 +170,7 @@ public:
 #ifdef USE_BOOST_PYTHON
 
     void Input_python_list(py::list& a_Inputs);
-    void Input_numpy(py::numeric::array& a_Inputs);
+    void Input_numpy(pyndarray& a_Inputs);
 
 #endif
 

--- a/src/PythonBindings.h
+++ b/src/PythonBindings.h
@@ -28,7 +28,14 @@
 #ifdef USE_BOOST_PYTHON
 
 #include <boost/python.hpp>
-#include <boost/python/numeric.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION < 106500
+    #include <boost/python/numeric.hpp>
+#else
+    #include <boost/python/numpy.hpp>
+#endif
+
 #include <boost/python/tuple.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
@@ -44,10 +51,17 @@ namespace py = boost::python;
 using namespace NEAT;
 using namespace py;
 
+#if BOOST_VERSION < 106500
+    typedef typename numeric::array pyndarray;
+#else
+    typedef typename numpy::ndarray pyndarray;
+#endif
 
 BOOST_PYTHON_MODULE(_MultiNEAT)
 {
-    numeric::array::set_module_and_type("numpy", "ndarray");
+    #if BOOST_VERSION < 106500
+        numeric::array::set_module_and_type("numpy", "ndarray");
+    #endif
 
 ///////////////////////////////////////////////////////////////////
 // Enums
@@ -132,7 +146,7 @@ BOOST_PYTHON_MODULE(_MultiNEAT)
     bool (NeuralNetwork::*NN_Load)(const char*) = &NeuralNetwork::Load;
     void (Genome::*Genome_Save)(const char*) = &Genome::Save;
     void (NeuralNetwork::*NN_Input)(py::list&) = &NeuralNetwork::Input_python_list;
-    void (NeuralNetwork::*NN_Input_numpy)(numeric::array&) = &NeuralNetwork::Input_numpy;
+    void (NeuralNetwork::*NN_Input_numpy)(pyndarray&) = &NeuralNetwork::Input_numpy;
     void (Parameters::*Parameters_Save)(const char*) = &Parameters::Save;
     int (Parameters::*Parameters_Load)(const char*) = &Parameters::Load;
 


### PR DESCRIPTION
From the boost 1.65 notes:

> The boost::python::numeric API has been removed, as it is being obsoleted by boost::python::numpy.