### PR TITLE
Adding Dockerfile to build MultiNEAT under Ubuntu 18.10 consistently.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.10
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y git cmake libboost-all-dev
+RUN apt-get update && apt-get install -y python-setuptools python-psutil python-numpy python-concurrent.futures python-opencv
+RUN cd /opt && git clone https://github.com/peter-ch/MultiNEAT.git
+RUN cd /opt/MultiNEAT && export MN_BUILD=boost && cmake . && python setup.py build_ext && python setup.py install
+
+
+


### PR DESCRIPTION
I found this a bit challenging to build at first so I created this Dockerfile to build and install it in a controlled environment.  I saw several people had created Issues about the build process so perhaps this will enable wider experimentation and reduce the barrier to entry.