### PR TITLE
libboost should not use 'boost_pythonXX' or 'boost_numpyXX'. 

### DIFF
--- a/examples/PythonObjectTraits.ipynb
+++ b/examples/PythonObjectTraits.ipynb
@@ -2,11 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pylab inline \n",
+    "%matplotlib inline \n",
     "\n",
     "import os\n",
     "import sys\n",
@@ -23,14 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,14 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,16 +85,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[ WARN:0@22.563] global loadsave.cpp:241 findDecoder imread_('smiley.jpg'): can't open/read file: check file path/integrity\n"
+     ]
+    },
+    {
+     "ename": "error",
+     "evalue": "OpenCV(4.10.0) /croot/opencv-suite_1722029125240/work/modules/imgproc/src/resize.cpp:4152: error: (-215:Assertion failed) !ssize.empty() in function 'resize'\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31merror\u001b[0m                                     Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# load the target picture\u001b[39;00m\n\u001b[1;32m      2\u001b[0m target_img \u001b[38;5;241m=\u001b[39m cv2\u001b[38;5;241m.\u001b[39mimread(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124msmiley.jpg\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 3\u001b[0m target_img \u001b[38;5;241m=\u001b[39m \u001b[43mcv2\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresize\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtarget_img\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m100\u001b[39;49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m100\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;241m/\u001b[39m \u001b[38;5;241m255\u001b[39m\n\u001b[1;32m      4\u001b[0m target_img \u001b[38;5;241m=\u001b[39m (target_img[:, :, \u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m+\u001b[39m target_img[:, :, \u001b[38;5;241m1\u001b[39m] \u001b[38;5;241m+\u001b[39m target_img[:, :, \u001b[38;5;241m2\u001b[39m])\u001b[38;5;241m/\u001b[39m\u001b[38;5;241m3\u001b[39m\n\u001b[1;32m      5\u001b[0m imshow(target_img); \u001b[38;5;28mprint\u001b[39m(target_img\u001b[38;5;241m.\u001b[39mshape)\n",
+      "\u001b[0;31merror\u001b[0m: OpenCV(4.10.0) /croot/opencv-suite_1722029125240/work/modules/imgproc/src/resize.cpp:4152: error: (-215:Assertion failed) !ssize.empty() in function 'resize'\n"
+     ]
+    }
+   ],
    "source": [
     "# load the target picture\n",
     "target_img = cv2.imread('smiley.jpg')\n",
@@ -116,13 +114,6 @@
     "target_img = (target_img[:, :, 0] + target_img[:, :, 1] + target_img[:, :, 2])/3\n",
     "imshow(target_img); print(target_img.shape)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -165,13 +156,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def evaluate_genome(genome):\n",
     "    # fitness is the inverse distance to the picture\n",
@@ -179,13 +163,6 @@
     "    ds = 1000 - np.mean((target_img - gimg)**2)\n",
     "    return ds"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -303,116 +280,11 @@
     "    except KeyboardInterrupt:\n",
     "        sys.stdout.flush()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "multineatENV",
    "language": "python",
    "name": "python3"
   },
@@ -426,7 +298,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.20"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ def getExtensions():
                         ]
             else:
                 # with boost 1.67+ you need boost_python3x and boost_numpy3x where x is python version 3.x 
-                libs += ['boost_python38', "boost_numpy38", "boost_system", 
+                libs += ['boost_python', "boost_numpy", "boost_system", 
                          'boost_filesystem', 'boost_serialization', 'boost_date_time', 
                          'boost_random']  # in Ubuntu 14 there is only 'boost_python-py34'
 


### PR DESCRIPTION
For newer python (libboost) versions 'boost_numpy', and 'boost_python' suffice in the setup.py file.